### PR TITLE
Add "how to build" instructions to the README

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "url": "git@gitlab.com:ticky/librarienne.git"
   },
   "author": "Jessica Stokes <hello@jessicastokes.net>",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "build": "gulp"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,3 +10,13 @@ A style for the [Textual IRC client](http://www.codeux.com/textual/).
 * Actions beginning with punctuation are treated as a full sentence, including the nickname
 * Automatic hyphenation of words in messages
 * Inline Open Graph previews (optionally)
+
+## Building
+
+Building Librarienne requires that Node.js (with npm) and Ruby be installed.
+
+1. `gem install sass`
+2. `npm install`
+3. `npm run build`
+
+After these three steps are run, the two Librarienne themes will be located in the "build" directory. To install, copy or move these directories into Textual's "Styles" directory.


### PR DESCRIPTION
It took me a little fumbling to figure out how to build this, so I thought I'd contribute instructions to the README. 😸 I also added a shortcut to the package.json to run gulp, for users who don't have it installed globally.
